### PR TITLE
Add ability to set Endpoint and Interface for devices with multiple choices

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -120,7 +120,7 @@ func main() {
 		found := false
 		hid.UsbWalk(func(device hid.Device) {
 			info := device.Info()
-			fmt.Printf("%04x:%04x:%04x\n", info.Vendor, info.Product, info.Revision)
+			fmt.Printf("%04x:%04x:%04x:%02x\n", info.Vendor, info.Product, info.Revision, info.Interface)
 			found = true
 		})
 		if !found {
@@ -131,7 +131,7 @@ func main() {
 
 	hid.UsbWalk(func(device hid.Device) {
 		info := device.Info()
-		id := fmt.Sprintf("%04x:%04x:%04x", info.Vendor, info.Product, info.Revision)
+		id := fmt.Sprintf("%04x:%04x:%04x:%02x", info.Vendor, info.Product, info.Revision, info.Interface)
 		if id != os.Args[1] {
 			return
 		}

--- a/hid.go
+++ b/hid.go
@@ -23,8 +23,6 @@ type Device interface {
 	Open() error
 	Close()
 	Info() Info
-	SetEndpoint(int)
-	SetInterface(int)
 	HIDReport() ([]byte, error)
 	SetReport(int, []byte) error
 	GetReport(int) ([]byte, error)

--- a/hid.go
+++ b/hid.go
@@ -24,6 +24,7 @@ type Device interface {
 	Close()
 	Info() Info
 	SetEndpoint(int)
+	SetInterface(int)
 	HIDReport() ([]byte, error)
 	SetReport(int, []byte) error
 	GetReport(int) ([]byte, error)

--- a/hid.go
+++ b/hid.go
@@ -23,6 +23,7 @@ type Device interface {
 	Open() error
 	Close()
 	Info() Info
+	SetEndpoint(int)
 	HIDReport() ([]byte, error)
 	SetReport(int, []byte) error
 	GetReport(int) ([]byte, error)

--- a/usb_linux.go
+++ b/usb_linux.go
@@ -27,6 +27,11 @@ type usbDevice struct {
 	path string
 }
 
+func (hid *usbDevice) SetEndpoint(ep int) {
+	hid.epOut = ep
+	hid.epIn = ep + 0x80
+}
+
 func (hid *usbDevice) Open() (err error) {
 	if hid.f != nil {
 		return errors.New("device is already opened")
@@ -34,7 +39,7 @@ func (hid *usbDevice) Open() (err error) {
 	if hid.f, err = os.OpenFile(hid.path, os.O_RDWR, 0644); err != nil {
 		return
 	} else {
-		return hid.claim()
+		return nil //hid.claim()
 	}
 }
 

--- a/usb_linux.go
+++ b/usb_linux.go
@@ -43,7 +43,7 @@ func (hid *usbDevice) Open() (err error) {
 	if hid.f, err = os.OpenFile(hid.path, os.O_RDWR, 0644); err != nil {
 		return
 	} else {
-		return nil //hid.claim()
+		return hid.claim()
 	}
 }
 

--- a/usb_linux.go
+++ b/usb_linux.go
@@ -32,6 +32,10 @@ func (hid *usbDevice) SetEndpoint(ep int) {
 	hid.epIn = ep + 0x80
 }
 
+func (hid *usbDevice) SetInterface(ifno int) {
+	hid.info.Interface = uint8(ifno)
+}
+
 func (hid *usbDevice) Open() (err error) {
 	if hid.f != nil {
 		return errors.New("device is already opened")


### PR DESCRIPTION
current lib breaks for devices that have multiple endpoints/interfaces, goes into an infinite loop when trying to claim or ends up communicating with the highest reported endpoint as opposed to the wanted one.

end goal should be to be able to choose from within a list that is built from usbWalk but for a quick fix being able to set it explicitly works, one can compare the info.Interface and epOut/epIn to know the amount of available interfaces/endpoints at least, assuming the device creator has used linear allocation
