### PR TITLE
GetReport: Optionally accept a buffer size.

### DIFF
--- a/hid.go
+++ b/hid.go
@@ -22,6 +22,23 @@ type Info struct {
 	Device    int
 }
 
+type getReportOptions struct {
+	bufferSize uint16
+}
+
+// GetReportOption is an optional argument to the GetReport function.
+type GetReportOption func(*getReportOptions)
+
+// WithBufferSize returns an option for the GetReport function that sets the
+// buffer size to use. The buffer size defaults to 256 bytes, which is not
+// suitable for some devices. Using this optional argument, the caller can use
+// a smaller or larger buffer.
+func WithBufferSize(sz uint16) GetReportOption {
+	return func(opts *getReportOptions) {
+		opts.bufferSize = sz
+	}
+}
+
 //
 // A common HID device interace
 //
@@ -31,7 +48,7 @@ type Device interface {
 	Info() Info
 	HIDReport() ([]byte, error)
 	SetReport(int, []byte) error
-	GetReport(int) ([]byte, error)
+	GetReport(int, ...GetReportOption) ([]byte, error)
 	Read(size int, ms time.Duration) ([]byte, error)
 	Write(data []byte, ms time.Duration) (int, error)
 	Ctrl(rtype, req, val, index int, data []byte, t int) (int, error)

--- a/usb_linux.go
+++ b/usb_linux.go
@@ -162,8 +162,15 @@ func (hid *usbDevice) HIDReport() ([]byte, error) {
 	}
 }
 
-func (hid *usbDevice) GetReport(report int) ([]byte, error) {
-	buf := make([]byte, 256, 256)
+func (hid *usbDevice) GetReport(report int, opts ...GetReportOption) ([]byte, error) {
+	opt := getReportOptions{
+		bufferSize: 256,
+	}
+	for _, o := range opts {
+		o(&opt)
+	}
+
+	buf := make([]byte, opt.bufferSize, opt.bufferSize)
 	// 10100001, GET_REPORT, type*256+id, intf, len, data
 	n, err := hid.ctrl(0xa1, 0x01, 3<<8+report, int(hid.info.Interface), buf, 1000)
 	if err != nil {


### PR DESCRIPTION
This implementation uses [Functional Options](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) to keep the argument optional while allowing for adding more options in a backwards compatible way. Most existing uses should continue to work, because the new argument is optional. Code that uses an interface such as

```go
type ReportGetter interface{
  GetReport(int) ([]byte, error)
}
```

will need to be updated though.

I tired striking a good balance between a small API surface and future extensibility. If you'd rather solve this differently, let me know and I'll happily reword the change.

Best regards,
—octo